### PR TITLE
Use Printf for formatted text

### DIFF
--- a/_extra/stemmer_test.go
+++ b/_extra/stemmer_test.go
@@ -9,7 +9,7 @@ import (
 func ExampleStem() {
 	words := []string{"worked", "working", "works"}
 	for _, w := range words {
-		fmt.Println("%s -> %s\n", w, stemmer.Stem(w))
+		fmt.Printf("%s -> %s\n", w, stemmer.Stem(w))
 	}
 
 	// Output:


### PR DESCRIPTION
I was working through lesson 6.8 and noticed this `Println` call was probably intended to be `Printf`.